### PR TITLE
fix: Add padding to detail page layout for desktop

### DIFF
--- a/glassmorphism/theme.css
+++ b/glassmorphism/theme.css
@@ -180,7 +180,9 @@ option {
 }
 
 /* Layout adjustments for desktop */
-.layout-desktop .detailPageContent {
+.layout-desktop .detailPageContent,
+.layout-desktop .infoWrapper, 
+.layout-desktop .mainDetailButtons{
   padding-left: 5%;
 }
 


### PR DESCRIPTION
Previously, the detail page layout was missing padding on desktop, causing misalignment with the rest of the content. This padding was present in forum/repo screenshots but not implemented. Added consistent padding to match the intended design.